### PR TITLE
Updates to make pykemon support python 3.4

### DIFF
--- a/pykemon/__init__.py
+++ b/pykemon/__init__.py
@@ -7,8 +7,8 @@ __version__ = '0.1.2'
 __copyright__ = 'Copyright Paul Hallett 2014'
 __license__ = 'BSD'
 
-from api import get
-from exceptions import ResourceNotFoundError
+from pykemon.api import get
+from pykemon.exceptions import ResourceNotFoundError
 
 
 """

--- a/pykemon/api.py
+++ b/pykemon/api.py
@@ -6,8 +6,8 @@
 User interaction with this package is done through this file.
 """
 
-from request import CHOICES
-from request import make_request
+from pykemon.request import CHOICES
+from pykemon.request import make_request
 
 
 def get(**kwargs):

--- a/pykemon/api.py
+++ b/pykemon/api.py
@@ -31,7 +31,7 @@ def get(**kwargs):
     if len(kwargs.keys()) > 1:
         raise ValueError('Too many arguments. Only pass 1 argument')
 
-    if kwargs.keys()[0] in CHOICES:
+    if list(kwargs.keys())[0] in CHOICES:
         return make_request(kwargs)
 
     else:

--- a/pykemon/models.py
+++ b/pykemon/models.py
@@ -21,6 +21,14 @@ class DateTimeObject(object):
         self.modified = bundle['modified']
 
 
+class Pokedex(DateTimeObject):
+    """
+    This class represents the pokedex
+    """
+    def __init__(self, bundle):
+        self.pokemon = buildr(bundle, 'pokemon')
+
+
 class Pokemon(DateTimeObject):
     """
     This class represents a single Pokemon resource

--- a/pykemon/request.py
+++ b/pykemon/request.py
@@ -59,8 +59,8 @@ def _compose(choice):
     Figure out exactly what resource we're requesting and return the correct
     class.
     """
-    nchoice = choice.keys()[0]
-    id = choice.values()[0]
+    nchoice = list(choice.keys())[0]
+    id = list(choice.values())[0]
 
     if '_id' in nchoice:
         nchoice = nchoice[:-3]
@@ -78,3 +78,4 @@ def make_request(choice):
 
     resource = CLASSES[nchoice]
     return resource(data)
+

--- a/pykemon/request.py
+++ b/pykemon/request.py
@@ -17,10 +17,11 @@ CHOICES = ['pokedex', 'pokedex_id', 'pokemon', 'pokemon_id', 'move', 'move_id',
 import requests
 import simplejson
 from simplejson import JSONDecodeError
-from pykemon.models import Pokemon, Move, Type, Ability, Egg, Description, Sprite, Game
+from pykemon.models import Pokedex, Pokemon, Move, Type, Ability, Egg, Description, Sprite, Game
 from pykemon.exceptions import ResourceNotFoundError
 
 CLASSES = {
+    'pokedex': Pokedex,
     'pokemon': Pokemon,
     'move': Move,
     'type': Type,
@@ -78,4 +79,3 @@ def make_request(choice):
 
     resource = CLASSES[nchoice]
     return resource(data)
-

--- a/pykemon/request.py
+++ b/pykemon/request.py
@@ -17,8 +17,8 @@ CHOICES = ['pokedex', 'pokedex_id', 'pokemon', 'pokemon_id', 'move', 'move_id',
 import requests
 import simplejson
 from simplejson import JSONDecodeError
-from models import Pokemon, Move, Type, Ability, Egg, Description, Sprite, Game
-from exceptions import ResourceNotFoundError
+from pykemon.models import Pokemon, Move, Type, Ability, Egg, Description, Sprite, Game
+from pykemon.exceptions import ResourceNotFoundError
 
 CLASSES = {
     'pokemon': Pokemon,

--- a/tests/test_pykemon.py
+++ b/tests/test_pykemon.py
@@ -17,6 +17,7 @@ import pykemon
 class TestPykemon(unittest.TestCase):
 
     def setUp(self):
+        self.pokedex_one = pykemon.get(pokedex=1)
         self.poke_one = pykemon.get(pokemon='bulbasaur')
         self.move_one = pykemon.get(move_id=15)  # Cut
         self.type_one = pykemon.get(type_id=10)  # Fire
@@ -27,6 +28,7 @@ class TestPykemon(unittest.TestCase):
         self.game_one = pykemon.get(game_id=4)  # Red
 
     def test_name_attribute(self):
+        self.assertEquals(self.pokedex_one.name, 'national')
         self.assertEquals(self.poke_one.name, 'Bulbasaur')
         self.assertEquals(self.move_one.name, 'Cut')
         self.assertEquals(self.type_one.name, 'Fire')
@@ -48,6 +50,7 @@ class TestPykemon(unittest.TestCase):
         self.assertEquals(str(self.game_one), '<Game - Red>')
 
     def test_resource_uri_attribute(self):
+        self.assertEquals(self.pokedex_one.resource_uri, '/api/v1/pokedex/1')
         self.assertEquals(self.poke_one.resource_uri, '/api/v1/pokemon/1/')
         self.assertEquals(self.move_one.resource_uri, '/api/v1/move/15/')
         self.assertEquals(self.type_one.resource_uri, '/api/v1/type/10/')


### PR DESCRIPTION
These two changesets make pykemon work with python 3.4
When install with pip pykemon does not correctly refrence its own includes which is fixed by prefixing import arguments with "pykemon." before the included file name

In python 3.4 dictionaries cannot be accessed through the use of a array access so we first pass it through the list() function. This results in a unordered dictionary but this seems to not be required by the dicts used in the api
