### PR TITLE
Correct imports

### DIFF
--- a/pykemon/__init__.py
+++ b/pykemon/__init__.py
@@ -7,8 +7,8 @@ __version__ = '0.2.0'
 __copyright__ = 'Copyright Paul Hallett 2016'
 __license__ = 'BSD'
 
-from api import get, V1Client  # NOQA
-from exceptions import ResourceNotFoundError  # NOQA
+from .api import get, V1Client  # NOQA
+from .exceptions import ResourceNotFoundError  # NOQA
 
 
 """


### PR DESCRIPTION
Currently your build on PyPI fails to import on any Python 3.0+ because of changes to the import system. The proposed changes fix that, and maintain compatibility with Python 2, although no one needs that.